### PR TITLE
Updated spec

### DIFF
--- a/specs/schema.json
+++ b/specs/schema.json
@@ -258,7 +258,7 @@
         }
       }
     },
-    "/{requestId}/reasons/{reasonId}/sttachments/{attachmentId}/download": {
+    "/{requestId}/reasons/{reasonId}/attachments/{attachmentId}/download": {
       "parameters": [
         {
           "in": "path",


### PR DESCRIPTION
Refactored so that

- date fields follow the CH convention using the `_on` suffice
- list responses use the CH convention having fields like `items_per_page` etc.
- fixed consistency in account/accounting period names
- child resources follow CH convention whereby the are referenced as links rather than full representation in the parent resource
- moved responsibility of triggering the downstream processing of the request to the input api via patching the status field on the resource
