### PR TITLE
delete attachment from request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
@@ -43,8 +43,15 @@ public class AttachmentsController {
     }
 
     @DeleteMapping("/{requestId}/reasons/{reasonId}/attachments/{attachmentId}")
-    public boolean deleteAttachmentFromRequest(@PathVariable String requestId, @PathVariable String attachmentId) {
-      return false;
+    public ResponseEntity<ChResponseBody<Void>> deleteAttachmentFromRequest(@PathVariable String requestId,
+          @PathVariable String reasonId, @PathVariable String attachmentId) {
+      try {
+          ServiceResult<Void> result = attachmentsService.removeAttachment(requestId, reasonId,
+              attachmentId);
+          return responseEntityFactory.createResponse(result);
+      } catch(ServiceException e) {
+          return responseEntityFactory.createResponse(ServiceResult.notFound());
+      }
     }
 
     @GetMapping("/{requestId}/reasons/{reasonId}/attachments/{attachmentId}")

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsService.java
@@ -3,14 +3,18 @@ package uk.gov.companieshouse.extensions.api.attachments;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestsRepository;
 import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.links.Links;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Service
 public class AttachmentsService {
@@ -34,16 +38,12 @@ public class AttachmentsService {
         attachment.setSize(file.getSize());
         attachment.setContentType(file.getContentType());
 
-        Optional<ExtensionRequestFullEntity> extension = requestsRepo.findById(requestId);
-        extension
-            .map(ExtensionRequestFullEntity::getReasons)
-            .filter(reasons -> !reasons.isEmpty())
-            .orElseThrow(() ->
-                new ServiceException(String.format("Attempting to add an attachment to request %s " +
-                    "that contains no Extension Reason.", requestId)))
-            .stream()
-            .filter(reason -> reason.getId().equals(reasonId))
-            .forEachOrdered(reason -> reason.addAttachment(attachment));
+        ExtensionRequestFullEntity extension = requestsRepo.findById(requestId)
+            .orElseThrow(missingRequest(requestId));
+
+        extension.mapToReason(reasonId)
+            .orElseThrow(missingReason(requestId, reasonId))
+            .addAttachment(attachment);
 
         String linkToSelf = attachmentsUri + "/" + randomUUID;
         Links links = new Links();
@@ -51,12 +51,51 @@ public class AttachmentsService {
         links.setLink(() -> "download", linkToSelf + "/download");
         attachment.setLinks(links);
 
-        requestsRepo.save(extension.get());
+        requestsRepo.save(extension);
 
         return ServiceResult.accepted(AttachmentDTO.builder()
             .withAttachment(attachment)
             .withFile(file)
             .withLinks(links)
             .build());
+    }
+
+    public ServiceResult<Void> removeAttachment(String requestId,
+            String reasonId, String attachmentId) throws ServiceException {
+        ExtensionRequestFullEntity extension = requestsRepo.findById(requestId)
+            .orElseThrow(missingRequest(requestId));
+
+        ExtensionReasonEntity reason = extension.mapToReason(reasonId)
+            .orElseThrow(missingReason(requestId, reasonId));
+
+        if(reason.getAttachments().isEmpty()) {
+            throw new ServiceException(String.format("Reason %s contains no attachment to delete: %s",
+                reasonId, attachmentId));
+        }
+
+        List<Attachment> updatedAttachments =
+            reason.getAttachments()
+                .stream()
+                .filter(attachment -> !attachment.getId().equals(attachmentId))
+                .collect(Collectors.toList());
+
+        if(updatedAttachments.size() == reason.getAttachments().size()) {
+            throw new ServiceException(String.format("Attachment %s does not exist in reason %s",
+                attachmentId, reasonId));
+        }
+
+        reason.setAttachments(updatedAttachments);
+
+        requestsRepo.save(extension);
+        return ServiceResult.deleted();
+    }
+
+    private Supplier<ServiceException> missingRequest(String requestId) {
+        return () -> new ServiceException(String.format("No request found: %s", requestId));
+    }
+
+    private Supplier<ServiceException> missingReason(String requestId, String reasonId) {
+        return () -> new ServiceException(String.format("Reason %s not found in " +
+            "Request %s", reasonId, requestId));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/ExtensionRequestFullEntity.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/ExtensionRequestFullEntity.java
@@ -2,9 +2,11 @@ package uk.gov.companieshouse.extensions.api.requests;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+import uk.gov.companieshouse.service.ServiceException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Document(collection = "extension_requests")
 public class ExtensionRequestFullEntity extends ExtensionRequestFull {
@@ -23,5 +25,11 @@ public class ExtensionRequestFullEntity extends ExtensionRequestFull {
 
     public void setReasons(List<ExtensionReasonEntity> reasons) {
         this.reasons = reasons;
+    }
+
+    public Optional<ExtensionReasonEntity> mapToReason(String reasonId) {
+        return reasons.stream()
+            .filter(reason -> reason.getId().equals(reasonId))
+            .findAny();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
@@ -91,21 +91,23 @@ public class AttachmentsControllerIntegrationTest {
 
     @Test
     public void testDeleteAttachmentFromRequest() throws Exception {
-       RequestBuilder requestBuilder = MockMvcRequestBuilders.delete(
-                SPECIFIC_URL).accept(
-                    MediaType.APPLICATION_JSON);
+        when(attachmentsService.removeAttachment(anyString(), anyString(), anyString()))
+            .thenReturn(ServiceResult.deleted());
+        RequestBuilder requestBuilder = MockMvcRequestBuilders
+            .delete(SPECIFIC_URL)
+            .accept(MediaType.APPLICATION_JSON);
 
-         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
-         assertEquals("false", result.getResponse().getContentAsString());
+        MvcResult result = mockMvc.perform(requestBuilder).andReturn();
+        assertEquals(HttpStatus.NO_CONTENT.value(), result.getResponse().getStatus());
     }
 
     @Test
     public void testDownloadAttachmentFromRequest() throws Exception {
-       RequestBuilder requestBuilder = MockMvcRequestBuilders.get(
-                SPECIFIC_URL).accept(
-                     MediaType.APPLICATION_JSON);
+        RequestBuilder requestBuilder = MockMvcRequestBuilders
+            .get(SPECIFIC_URL)
+            .accept(MediaType.APPLICATION_JSON);
 
-         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
-         assertEquals("Getting attachment", result.getResponse().getContentAsString());
+        MvcResult result = mockMvc.perform(requestBuilder).andReturn();
+        assertEquals("Getting attachment", result.getResponse().getContentAsString());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerUnitTest.java
@@ -28,7 +28,7 @@ public class AttachmentsControllerUnitTest {
     private HttpServletRequest servletRequest;
 
     @Test
-    public void willReturn404IfInvalidRequestSupplied() throws Exception {
+    public void willReturn404IfInvalidRequestSuppliedPostRequest() throws Exception {
         when(servletRequest.getRequestURI()).thenReturn("url");
         when(attachmentsService.addAttachment(any(MultipartFile.class), anyString(), anyString(),
             anyString())).thenThrow(new ServiceException("exception error"));
@@ -39,6 +39,21 @@ public class AttachmentsControllerUnitTest {
 
         ResponseEntity entity = controller.uploadAttachmentToRequest(Utils.mockMultipartFile(),
             "123","1234", servletRequest);
+
+        assertEquals(HttpStatus.NOT_FOUND, entity.getStatusCode());
+    }
+
+    @Test
+    public void willReturn404IfInvalidRequestSuppliedDeleteRequest() throws Exception {
+        when(attachmentsService.removeAttachment(anyString(), anyString(),
+            anyString())).thenThrow(new ServiceException("exception error"));
+
+        AttachmentsController controller =
+            new AttachmentsController(PluggableResponseEntityFactory.buildWithStandardFactories(),
+                attachmentsService);
+
+        ResponseEntity entity = controller.deleteAttachmentFromRequest(
+            "123","1234", "12345");
 
         assertEquals(HttpStatus.NOT_FOUND, entity.getStatusCode());
     }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
@@ -81,6 +81,7 @@ public class RequestRepositoryIntegrationTest {
 
         assertEquals("string", actualReason.getAdditionalText());
         assertNotNull(actualReason.getId());
+        assertTrue(actualReason.getAttachments().isEmpty());
         assertEquals("illness", actualReason.getReason());
     }
 


### PR DESCRIPTION
Add the delete endpoint for removing an attachment from a request.
So far this will only remove the attachment from the database and not the actual uploaded attachment file. (integration with the file uploader api will come in the next sprint)