### PR TITLE
add reasonId to contract

### DIFF
--- a/specs/schema.json
+++ b/specs/schema.json
@@ -620,6 +620,10 @@
     "ExtensionReason": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
         "etag": {
           "type": "string"
         },


### PR DESCRIPTION
A post request for a new reason should return the id of that reason.
We cannot add to that reason if we dont know what reason we have created.