### PR TITLE
add a full request to the return

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
@@ -65,10 +65,9 @@ public class RequestsController {
     }
 
     @GetMapping("/{requestId}")
-    public ResponseEntity<ExtensionRequestFullDTO> getSingleExtensionRequestById(@PathVariable String
+    public ResponseEntity<ExtensionRequestFullEntity> getSingleExtensionRequestById(@PathVariable String
                                                                             requestId) {
         return requestsService.getExtensionsRequestById(requestId)
-            .map(extensionRequestMapper::entityToDTO)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
@@ -96,23 +96,22 @@ public class RequestControllerUnitTest {
 
     @Test
     public void canGetSingleExtensionRequest() {
-        ExtensionRequestFullEntity extensionRequestFullEntity = new ExtensionRequestFullEntity();
-        ExtensionRequestFullDTO extensionRequestFullDTO = dummyRequestDTO();
+        ExtensionRequestFullEntity extensionRequestFullEntity = dummyRequestEntity();
 
         when(requestsService.getExtensionsRequestById("1234")).thenReturn(Optional.of(extensionRequestFullEntity));
-        when(mockExtensionRequestMapper.entityToDTO(extensionRequestFullEntity)).thenReturn(extensionRequestFullDTO);
 
-        ResponseEntity<ExtensionRequestFullDTO> response = controller.getSingleExtensionRequestById
+        ResponseEntity<ExtensionRequestFullEntity> response =
+            controller.getSingleExtensionRequestById
             ("1234");
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(extensionRequestFullDTO, response.getBody());
+        assertEquals(extensionRequestFullEntity, response.getBody());
     }
 
     @Test
     public void canGetSingleExtensionRequest_NotFound() {
         when(requestsService.getExtensionsRequestById("1234")).thenReturn(Optional.ofNullable(null));
-        ResponseEntity<ExtensionRequestFullDTO> response = controller.getSingleExtensionRequestById
+        ResponseEntity<ExtensionRequestFullEntity> response = controller.getSingleExtensionRequestById
             ("1234");
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());


### PR DESCRIPTION
The web depends on a full request response to display reason information.
If a full request only returns links then there could potentially be many api requests for information that should be available in the first request.