### PR TITLE
getRequest returns full entity

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/ExtensionRequestFullEntity.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/ExtensionRequestFullEntity.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
-import org.springframework.data.mongodb.core.mapping.Document;
-import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
-import uk.gov.companieshouse.service.ServiceException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
 
 @Document(collection = "extension_requests")
 public class ExtensionRequestFullEntity extends ExtensionRequestFull {

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
@@ -65,10 +65,9 @@ public class RequestsController {
     }
 
     @GetMapping("/{requestId}")
-    public ResponseEntity<ExtensionRequestFullDTO> getSingleExtensionRequestById(@PathVariable String
+    public ResponseEntity<ExtensionRequestFullEntity> getSingleExtensionRequestById(@PathVariable String
                                                                             requestId) {
         return requestsService.getExtensionsRequestById(requestId)
-            .map(extensionRequestMapper::entityToDTO)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
@@ -9,6 +9,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import uk.gov.companieshouse.extensions.api.attachments.Attachment;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+
 import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -87,8 +90,8 @@ public class RequestControllerUnitTest {
 
     @Test
     public void canGetExtensionRequestList() {
-        final ExtensionRequestFull expectedRequest = new ExtensionRequestFullDTO();
         List<ExtensionRequestFullDTO> response = controller.getExtensionRequestsList();
+        assertFalse(response.isEmpty());
         response.forEach(request -> {
            assertNotNull(request.getId());
         });
@@ -97,22 +100,26 @@ public class RequestControllerUnitTest {
     @Test
     public void canGetSingleExtensionRequest() {
         ExtensionRequestFullEntity extensionRequestFullEntity = new ExtensionRequestFullEntity();
-        ExtensionRequestFullDTO extensionRequestFullDTO = dummyRequestDTO();
-
+        extensionRequestFullEntity.setId("1234");
+        ExtensionReasonEntity reasonEntity = new ExtensionReasonEntity();
+        reasonEntity.setId("reason1");
+        Attachment attachment = new Attachment();
+        attachment.setId("attachment1");
+        reasonEntity.addAttachment(attachment);
+        extensionRequestFullEntity.addReason(reasonEntity);
         when(requestsService.getExtensionsRequestById("1234")).thenReturn(Optional.of(extensionRequestFullEntity));
-        when(mockExtensionRequestMapper.entityToDTO(extensionRequestFullEntity)).thenReturn(extensionRequestFullDTO);
 
-        ResponseEntity<ExtensionRequestFullDTO> response = controller.getSingleExtensionRequestById
+        ResponseEntity<ExtensionRequestFullEntity> response = controller.getSingleExtensionRequestById
             ("1234");
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(extensionRequestFullDTO, response.getBody());
+        assertEquals(extensionRequestFullEntity, response.getBody());
     }
 
     @Test
     public void canGetSingleExtensionRequest_NotFound() {
         when(requestsService.getExtensionsRequestById("1234")).thenReturn(Optional.ofNullable(null));
-        ResponseEntity<ExtensionRequestFullDTO> response = controller.getSingleExtensionRequestById
+        ResponseEntity<ExtensionRequestFullEntity> response = controller.getSingleExtensionRequestById
             ("1234");
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());


### PR DESCRIPTION
resolves [LFA-674](https://companieshouse.atlassian.net/browse/LFA-674)

The contract for a full request has changed. This was preventing us from getting attachments and reasons without multiple requests for the summary page.

The getRequest endpoint now returns the full entity rather than the DTO