### PR TITLE
Adding company number to logger

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/logger/ApiLogger.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/logger/ApiLogger.java
@@ -10,9 +10,18 @@ import java.util.Map;
 @Component
 public class ApiLogger {
     private static final Logger LOG = LoggerFactory.getLogger(Application.APP_NAMESPACE);
+    private static final ThreadLocal<String> COMPANY_NUMBER = new ThreadLocal<>();
+
+    public void setCompanyNumber(String companyNumber) {
+        COMPANY_NUMBER.set(companyNumber);
+    }
+
+    public void removeCompanyNumber() {
+        COMPANY_NUMBER.remove();
+    }
 
     private String prefix(String message) {
-        return "Thread id " + Thread.currentThread().getId() + " - " + message;
+        return "CompanyNumber = " + COMPANY_NUMBER.get() + " - Thread id " + Thread.currentThread().getId() + " - " + message;
     }
 
     public void debug(String message) {

--- a/src/main/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptor.java
@@ -13,6 +13,8 @@ public class RequestLoggerInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String companyNumber = getCompanyNumber(request);
+        logger.setCompanyNumber(companyNumber);
         String requestPath = getRequestMessage(request);
         logger.info("Request received - " + requestPath);
         return true; //continue on to next handler
@@ -25,6 +27,27 @@ public class RequestLoggerInterceptor extends HandlerInterceptorAdapter {
         } else {
             logger.error(ex);
         }
+        logger.removeCompanyNumber();
+    }
+
+    /**
+     * This splits the uri by "/" and searches the uri for "company" and assumes that the company number follows it
+     * e.g. /company/00006400/extensions/requests
+     * @param request
+     * @return company number or empty string if not found
+     */
+    private String getCompanyNumber(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        boolean isPreviousTokenCompany = false;
+        for (String token : uri.split("/")) {
+            if (isPreviousTokenCompany) {
+                return token;
+            }
+            if ("company".equals(token)) {
+                isPreviousTokenCompany = true;
+            }
+        }
+        return "";
     }
 
     private String getRequestMessage(HttpServletRequest request) {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
@@ -28,13 +28,14 @@ public class RequestLoggerInterceptorTest {
         response = new MockHttpServletResponse();
         request = new MockHttpServletRequest();
         request.setMethod("POST");
-        request.setRequestURI("some uri");
+        request.setRequestURI("/company/00006400/extensions/requests");
     }
 
     @Test
     public void testPreHandler() {
         interceptor.preHandle(request, response, new Object());
 
+        Mockito.verify(logger).setCompanyNumber("00006400");
         Mockito.verify(logger).info("Request received - " + request.getMethod() + " " + request.getRequestURI());
     }
 
@@ -43,6 +44,7 @@ public class RequestLoggerInterceptorTest {
         interceptor.afterCompletion(request, response, new Object(), null);
 
         Mockito.verify(logger).info("Request finished - " + request.getMethod() + " " + request.getRequestURI());
+        Mockito.verify(logger).removeCompanyNumber();
     }
 
     @Test


### PR DESCRIPTION
Adding a thread local to the logger to capture the company number. This will be set by the request interceptor so when we receive a new quest we capture the company number that will be used in all log messages for that thread. The interceptor removes the company number after completion of the request.