### PR TITLE
Adding response status to the exit log of the request interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptor.java
@@ -22,11 +22,13 @@ public class RequestLoggerInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        String responseStatus = "response status = " + response.getStatus();
         if (ex == null) {
-            logger.info("Request finished - " + getRequestMessage(request));
+            logger.info("Request finished - " + responseStatus + " - " + getRequestMessage(request));
         } else {
-            logger.error(ex);
+            logger.error(responseStatus, ex);
         }
+        //remove the company number from the threadlocal var in the logger
         logger.removeCompanyNumber();
     }
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
@@ -26,6 +26,8 @@ public class RequestLoggerInterceptorTest {
     @Before
     public void setup() {
         response = new MockHttpServletResponse();
+        response.setStatus(200);
+
         request = new MockHttpServletRequest();
         request.setMethod("POST");
         request.setRequestURI("/company/00006400/extensions/requests");
@@ -43,7 +45,7 @@ public class RequestLoggerInterceptorTest {
     public void testAfterCompletion_noException() {
         interceptor.afterCompletion(request, response, new Object(), null);
 
-        Mockito.verify(logger).info("Request finished - " + request.getMethod() + " " + request.getRequestURI());
+        Mockito.verify(logger).info("Request finished - response status = " + response.getStatus() + " - " + request.getMethod() + " " + request.getRequestURI());
         Mockito.verify(logger).removeCompanyNumber();
     }
 
@@ -52,6 +54,6 @@ public class RequestLoggerInterceptorTest {
         Exception e = new Exception();
         interceptor.afterCompletion(request, response, new Object(), e);
 
-        Mockito.verify(logger).error(e);
+        Mockito.verify(logger).error("response status = " + response.getStatus(), e);
     }
 }


### PR DESCRIPTION
When the request has finished the logs should now contain the http status for the response eg. 404 etc..