### PR TITLE
modify schema to process and empty post request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 *.iml
 *.jar
 .DS_Store
+.factorypath
+.vscode/

--- a/specs/schema.json
+++ b/specs/schema.json
@@ -315,22 +315,6 @@
         }
       ],
       "post": {
-        "parameters": [
-          {
-            "in": "body",
-            "name": "status",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "format": "uuid",
-                  "description": "the extension request id"
-                }
-              }
-            }
-          }
-        ],
         "tags": [
           "Processor API"
         ],


### PR DESCRIPTION
The processor API has a post request to change the status of an extension from open to closed.

The body of that post request contains the extension request id. But this is already supplied within the request path.
Remove the post body and instead have an empty post request