### PR TITLE
allow sonar to detect all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,19 @@ test: clean
 
 .PHONY: test-unit
 test-unit: clean
-	mvn verify -Punit-test
+	mvn test -Dgroups="uk.gov.companieshouse.extensions.api.groups.Unit"
 
 .PHONY: test-integration
 test-integration: clean
-	mvn verify -Pintegration-test
+	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.Integration"
+
+.PHONY: test-contract-consumer
+test-contract-consumer: clean
+	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.ContractConsumer"
+
+.PHONY: test-contract-provider
+test-contract-provider: clean
+	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.ContractProvider"
 
 .PHONY: dev
 dev: clean

--- a/pom.xml
+++ b/pom.xml
@@ -138,40 +138,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
-          <executions>
-          <execution>
-            <id>default-test</id>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </execution>
-          <execution>
-            <id>unit-tests</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skipTests>${skip.unit.tests}</skipTests>
-              <includes>
-                <include>**UnitTest.java</include>
-              </includes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>integration-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skipTests>${skip.integration.tests}</skipTests>
-              <includes>
-                <include>**IntegrationTest.java</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -192,35 +158,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>unit-test</id>
-      <properties>
-        <build.profile.id>unit-test</build.profile.id>
-        <skip.integration.tests>true</skip.integration.tests>
-        <skip.unit.tests>false</skip.unit.tests>
-      </properties>
-    </profile>
-    <profile>
-      <id>integration-test</id>
-      <properties>
-        <build.profile.id>integration-test</build.profile.id>
-        <skip.integration.tests>false</skip.integration.tests>
-        <skip.unit.tests>true</skip.unit.tests>
-      </properties>
-    </profile>
-    <profile>
-      <id>all-test</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <build.profile.id>all-test</build.profile.id>
-        <skip.integration.tests>false</skip.integration.tests>
-        <skip.unit.tests>false</skip.unit.tests>
-      </properties>
-    </profile>
-  </profiles>
 
 </project>

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentDTOUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentDTOUnitTest.java
@@ -1,15 +1,20 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.springframework.web.multipart.MultipartFile;
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
-import uk.gov.companieshouse.service.links.Links;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.web.multipart.MultipartFile;
+
+import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.service.links.Links;
+
+@Category(Unit.class)
 public class AttachmentDTOUnitTest {
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
@@ -1,8 +1,19 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,19 +29,13 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.multipart.MultipartFile;
+
+import uk.gov.companieshouse.extensions.api.groups.Integration;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.HashMap;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-
+@Category(Integration.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerUnitTest.java
@@ -1,25 +1,29 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.multipart.MultipartFile;
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
-import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
-import uk.gov.companieshouse.service.ServiceException;
-import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
-
-import javax.servlet.http.HttpServletRequest;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
+import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
+
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class AttachmentsControllerUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsServiceUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsServiceUnitTest.java
@@ -1,20 +1,15 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.web.multipart.MultipartFile;
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
-import uk.gov.companieshouse.extensions.api.attachments.upload.FileUploader;
-import uk.gov.companieshouse.extensions.api.attachments.upload.FileUploaderResponse;
-import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
-import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
-import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestsRepository;
-import uk.gov.companieshouse.service.ServiceException;
-import uk.gov.companieshouse.service.ServiceResult;
-import uk.gov.companieshouse.service.ServiceResultStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,10 +17,26 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.web.multipart.MultipartFile;
 
+import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import uk.gov.companieshouse.extensions.api.attachments.upload.FileUploader;
+import uk.gov.companieshouse.extensions.api.attachments.upload.FileUploaderResponse;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
+import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestsRepository;
+import uk.gov.companieshouse.service.ServiceException;
+import uk.gov.companieshouse.service.ServiceResult;
+import uk.gov.companieshouse.service.ServiceResultStatus;
+
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class AttachmentsServiceUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/upload/FileUploaderTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/upload/FileUploaderTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.extensions.api.attachments.upload;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -16,13 +17,16 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class FileUploaderTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/groups/ContractConsumer.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/groups/ContractConsumer.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.extensions.api.groups;
+
+public interface ContractConsumer {
+}

--- a/src/test/java/uk/gov/companieshouse/extensions/api/groups/ContractProvider.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/groups/ContractProvider.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.extensions.api.groups;
+
+public interface ContractProvider {
+}

--- a/src/test/java/uk/gov/companieshouse/extensions/api/groups/Integration.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/groups/Integration.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.extensions.api.groups;
+
+public interface Integration {
+}

--- a/src/test/java/uk/gov/companieshouse/extensions/api/groups/Unit.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/groups/Unit.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.extensions.api.groups;
+
+public interface Unit {
+}

--- a/src/test/java/uk/gov/companieshouse/extensions/api/logger/LogMethodCallAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/logger/LogMethodCallAspectTest.java
@@ -1,16 +1,20 @@
 package uk.gov.companieshouse.extensions.api.logger;
 
+import java.lang.reflect.Method;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Method;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class LogMethodCallAspectTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/logger/RequestLoggerInterceptorTest.java
@@ -1,7 +1,10 @@
 package uk.gov.companieshouse.extensions.api.logger;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -9,8 +12,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import javax.servlet.http.HttpServletResponse;
 
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class RequestLoggerInterceptorTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/processor/ProcessorControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/processor/ProcessorControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.extensions.api.processor;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -13,11 +14,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
 import org.springframework.web.client.RestTemplate;
-import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
-import uk.gov.companieshouse.extensions.api.processor.ProcessorController;
 
+import uk.gov.companieshouse.extensions.api.groups.Integration;
+import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
+
+@Category(Integration.class)
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = ProcessorController.class)
 public class ProcessorControllerIntegrationTest {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/processor/ProcessorControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/processor/ProcessorControllerUnitTest.java
@@ -1,9 +1,13 @@
 package uk.gov.companieshouse.extensions.api.processor;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+
+@Category(Unit.class)
 public class ProcessorControllerUnitTest {
 
     private ProcessorController processorController = new ProcessorController();

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonEntityBuilderUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonEntityBuilderUnitTest.java
@@ -6,10 +6,13 @@ import java.time.LocalDate;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 import uk.gov.companieshouse.service.links.Links;
 
+@Category(Unit.class)
 public class ExtensionReasonEntityBuilderUnitTest {
 
   @Rule

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/PatchReasonMapperUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/PatchReasonMapperUnitTest.java
@@ -1,12 +1,16 @@
 package uk.gov.companieshouse.extensions.api.reasons;
 
-import org.junit.Test;
-import uk.gov.companieshouse.service.links.Links;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDate;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.service.links.Links;
+
+@Category(Unit.class)
 public class PatchReasonMapperUnitTest {
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonMapperUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonMapperUnitTest.java
@@ -1,11 +1,15 @@
 package uk.gov.companieshouse.extensions.api.reasons;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+
+@Category(Unit.class)
 public class ReasonMapperUnitTest {
 
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonServiceUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonServiceUnitTest.java
@@ -1,7 +1,23 @@
 package uk.gov.companieshouse.extensions.api.reasons;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.REQUEST_ID;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyCreateReason;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -9,6 +25,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestsRepository;
 import uk.gov.companieshouse.extensions.api.requests.RequestsService;
@@ -18,16 +36,7 @@ import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.ServiceResultStatus;
 import uk.gov.companieshouse.service.links.Links;
 
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.*;
-
-
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class ReasonServiceUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsControllerIntegrationTest.java
@@ -1,6 +1,18 @@
 package uk.gov.companieshouse.extensions.api.reasons;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
+
+import java.util.Arrays;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,24 +24,15 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.client.RestTemplate;
+
+import uk.gov.companieshouse.extensions.api.groups.Integration;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
 import uk.gov.companieshouse.extensions.api.response.ListResponse;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.links.Links;
-import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
 
-import javax.servlet.http.HttpServletRequest;
-
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
-
+@Category(Integration.class)
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = ReasonsController.class)
 public class ReasonsControllerIntegrationTest {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsControllerUnitTest.java
@@ -1,13 +1,33 @@
 package uk.gov.companieshouse.extensions.api.reasons;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.BASE_URL;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.REASON_ID;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.REQUEST_ID;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyCreateReason;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
 import uk.gov.companieshouse.extensions.api.response.ListResponse;
@@ -17,17 +37,7 @@ import uk.gov.companieshouse.service.links.Links;
 import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.*;
-
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class ReasonsControllerUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/ERICHeaderParserUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/ERICHeaderParserUnitTest.java
@@ -1,13 +1,19 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
 import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import javax.servlet.http.HttpServletRequest;
 
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class ERICHeaderParserUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerIntegrationTest.java
@@ -1,6 +1,19 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.COMPANY_NUMBER;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,22 +25,12 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.client.RestTemplate;
+
 import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import uk.gov.companieshouse.extensions.api.groups.Integration;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.COMPANY_NUMBER;
-
+@Category(Integration.class)
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = RequestsController.class)
 public class RequestControllerIntegrationTest {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
@@ -1,26 +1,5 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
-import uk.gov.companieshouse.extensions.api.attachments.Attachment;
-import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
-import uk.gov.companieshouse.extensions.api.response.ListResponse;
-
-import javax.servlet.http.HttpServletRequest;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -38,6 +17,31 @@ import static uk.gov.companieshouse.extensions.api.Utils.Utils.USER_ID;
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestDTO;
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import uk.gov.companieshouse.extensions.api.attachments.Attachment;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+import uk.gov.companieshouse.extensions.api.response.ListResponse;
+
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class RequestControllerUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestMapperUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestMapperUnitTest.java
@@ -1,17 +1,21 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.REQUEST_ID;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.TESTURI;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyReasonEntity;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
 
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
-import uk.gov.companieshouse.service.links.LinkKey;
 import uk.gov.companieshouse.service.links.Links;
 
-import java.util.Map;
-
-import static org.junit.Assert.*;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.*;
-
+@Category(Unit.class)
 public class RequestMapperUnitTest {
 
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
@@ -1,15 +1,9 @@
 package uk.gov.companieshouse.extensions.api.requests;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Sort;
-import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
-import uk.gov.companieshouse.extensions.api.attachments.Attachment;
-import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
-import uk.gov.companieshouse.service.links.Links;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,8 +12,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.gov.companieshouse.extensions.api.Utils.Utils;
+import uk.gov.companieshouse.extensions.api.attachments.Attachment;
+import uk.gov.companieshouse.extensions.api.groups.Integration;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+import uk.gov.companieshouse.service.links.Links;
+
+@Category(Integration.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class RequestRepositoryIntegrationTest {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestServiceUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestServiceUnitTest.java
@@ -2,10 +2,23 @@ package uk.gov.companieshouse.extensions.api.requests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-import static uk.gov.companieshouse.extensions.api.Utils.Utils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.COMPANY_NUMBER;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.REQUEST_ID;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.TESTURI;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.createdBy;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyCreateRequestEntity;
+import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -13,10 +26,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.function.Supplier;
+import uk.gov.companieshouse.extensions.api.groups.Unit;
 
+@Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class RequestServiceUnitTest {
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/response/ListResponseUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/response/ListResponseUnitTest.java
@@ -1,15 +1,20 @@
 package uk.gov.companieshouse.extensions.api.response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-
-import java.util.Arrays;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+
+@Category(Unit.class)
 public class ListResponseUnitTest {
 
     @Test


### PR DESCRIPTION
Annotate with tewst classes with junit @Category which will allow use to isolate unit/integration/contract tests so they can be run in parallel in concourse.

This is a required step for implementing contract test which are being developed in extension-processor-api.

This will also allow sonar to pick up every test and increase our coverage stat