### PR TITLE
add patch request for completing an application

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/PatchRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/PatchRequestMapper.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.extensions.api.requests;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface PatchRequestMapper {
+
+    PatchRequestMapper INSTANCE = Mappers.getMapper(PatchRequestMapper.class);
+
+    ExtensionRequestFullEntity patchEntity(RequestStatus patchEntity,
+                                          @MappingTarget ExtensionRequestFullEntity databaseEntity);
+}

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestStatus.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestStatus.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.extensions.api.requests;
+
+public class RequestStatus {
+
+    private Status status;
+
+    public Status getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.extensions.api.logger.LogMethodCall;
 import uk.gov.companieshouse.extensions.api.response.ListResponse;
+import uk.gov.companieshouse.service.ServiceException;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -34,9 +36,8 @@ public class RequestsController {
     @LogMethodCall
     @PostMapping("/")
     public ResponseEntity<ExtensionRequestFullDTO> createExtensionRequestResource(
-        @RequestBody ExtensionCreateRequest extensionCreateRequest,
-        HttpServletRequest request,
-        @PathVariable String companyNumber) {
+            @RequestBody ExtensionCreateRequest extensionCreateRequest, HttpServletRequest request,
+            @PathVariable String companyNumber) {
 
         CreatedBy createdBy = new CreatedBy();
         createdBy.setId(ericHeaderParser.getUserId(request));
@@ -44,44 +45,50 @@ public class RequestsController {
         createdBy.setForename(ericHeaderParser.getForename(request));
         createdBy.setSurname(ericHeaderParser.getSurname(request));
 
-         String reqUri = request.getRequestURI();
+        String reqUri = request.getRequestURI();
 
         ExtensionRequestFullEntity extensionRequestFullEntity = requestsService
-            .insertExtensionsRequest
-            (extensionCreateRequest, createdBy, reqUri, companyNumber);
+                .insertExtensionsRequest(extensionCreateRequest, createdBy, reqUri, companyNumber);
 
-        ExtensionRequestFullDTO extensionRequestFullDTO = extensionRequestMapper.entityToDTO
-            (extensionRequestFullEntity);
+        ExtensionRequestFullDTO extensionRequestFullDTO = extensionRequestMapper
+                .entityToDTO(extensionRequestFullEntity);
 
-        return ResponseEntity.created(
-            URI.create(extensionRequestFullEntity
-                .getLinks()
-                .getLink(ExtensionsLinkKeys.SELF)))
-            .body(extensionRequestFullDTO);
+        return ResponseEntity
+                .created(URI.create(extensionRequestFullEntity.getLinks().getLink(ExtensionsLinkKeys.SELF)))
+                .body(extensionRequestFullDTO);
     }
 
     @LogMethodCall
     @GetMapping("/")
     public ResponseEntity<ListResponse<ExtensionRequestFullDTO>> getExtensionRequestsListByCompanyNumber(
-        @PathVariable String companyNumber) {
+            @PathVariable String companyNumber) {
 
         List<ExtensionRequestFullDTO> requestFullDTOList = requestsService
-            .getExtensionsRequestListByCompanyNumber(companyNumber).stream().map
-                (extensionRequestMapper::entityToDTO).collect(Collectors.toList());
+                .getExtensionsRequestListByCompanyNumber(companyNumber).stream()
+                .map(extensionRequestMapper::entityToDTO).collect(Collectors.toList());
 
         ListResponse<ExtensionRequestFullDTO> extensionRequestList = ListResponse.<ExtensionRequestFullDTO>builder()
-            .withItems(requestFullDTOList)
-            .build();
+                .withItems(requestFullDTOList).build();
         return ResponseEntity.ok(extensionRequestList);
     }
 
     @LogMethodCall
     @GetMapping("/{requestId}")
-    public ResponseEntity<ExtensionRequestFullEntity> getSingleExtensionRequestById(@PathVariable String
-                                                                            requestId) {
-        return requestsService.getExtensionsRequestById(requestId)
-            .map(ResponseEntity::ok)
-            .orElse(ResponseEntity.notFound().build());
+    public ResponseEntity<ExtensionRequestFullEntity> getSingleExtensionRequestById(@PathVariable String requestId) {
+        return requestsService.getExtensionsRequestById(requestId).map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @LogMethodCall
+    @PatchMapping("/{requestId}")
+    public ResponseEntity<ExtensionRequestFullEntity> patchRequest(@PathVariable String requestId,
+            @RequestBody RequestStatus requestStatus) {
+        try {
+            requestsService.patchRequest(requestId, requestStatus);
+            return ResponseEntity.noContent().build();
+        } catch (ServiceException e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @LogMethodCall

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsService.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.extensions.api.logger.LogMethodCall;
+import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.links.Links;
 
 import java.time.LocalDateTime;
@@ -28,6 +29,15 @@ public class RequestsService {
     @LogMethodCall
     public List<ExtensionRequestFullEntity> getExtensionsRequestListByCompanyNumber(String companyNumber) {
         return extensionRequestsRepository.findAllByCompanyNumber(companyNumber, Sort.by("_id").descending());
+    }
+
+    @LogMethodCall
+    public ExtensionRequestFullEntity patchRequest(String requestId, RequestStatus status) throws ServiceException {
+        ExtensionRequestFullEntity entity = extensionRequestsRepository.findById(requestId)
+                .orElseThrow(() -> new ServiceException(String.format("Request: %s cannot be found", requestId)));
+
+        entity = PatchRequestMapper.INSTANCE.patchEntity(status, entity);
+        return extensionRequestsRepository.save(entity);
     }
 
     public ExtensionRequestFullEntity insertExtensionsRequest(ExtensionCreateRequest extensionCreateRequest, CreatedBy

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/PatchRequestMapperUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/PatchRequestMapperUnitTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.extensions.api.requests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import uk.gov.companieshouse.extensions.api.groups.Unit;
+import uk.gov.companieshouse.extensions.api.reasons.ExtensionReasonEntity;
+import uk.gov.companieshouse.service.links.Links;
+
+@Category(Unit.class)
+public class PatchRequestMapperUnitTest {
+
+    @Test
+    public void canMergeAPatchEntityIntoADatabaseEntity() {
+        RequestStatus patchEntity = new RequestStatus();
+        patchEntity.setStatus(Status.SUBMITTED);
+
+        ExtensionRequestFullEntity dbEntity = new ExtensionRequestFullEntity();
+        dbEntity.setId("12345");
+        dbEntity.setAccountingPeriodEndOn(LocalDate.of(2018,1,1));
+        Links links = new Links();
+        links.setLink(ExtensionsLinkKeys.SELF, "something");
+        dbEntity.setLinks(links);
+
+        ExtensionReasonEntity reason = new ExtensionReasonEntity();
+        reason.setId("reason1");
+        dbEntity.setReasons(Arrays.asList(reason));
+
+        ExtensionRequestFullEntity mappedEntity = PatchRequestMapper.INSTANCE
+            .patchEntity(patchEntity, dbEntity);
+
+        assertEquals("12345", mappedEntity.getId());
+        assertEquals(LocalDate.of(2018,1,1), mappedEntity.getAccountingPeriodEndOn());
+        assertEquals(links, mappedEntity.getLinks());
+        assertEquals(Status.SUBMITTED, dbEntity.getStatus());
+        assertEquals("reason1", dbEntity.getReasons().get(0).getId());
+    }
+  
+}


### PR DESCRIPTION
Submitting an application requires implementing the patch endpoint for a request. This was missed and so a 405 will always be returned when integrating with the extensions api