### PR TITLE
remove brittle state check

### DIFF
--- a/src/test/java/uk/gov/companieshouse/extensions/api/contract/ContractProviderIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/contract/ContractProviderIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.extensions.api.contract;
 
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import au.com.dius.pact.provider.junit.Provider;
@@ -13,9 +12,6 @@ import au.com.dius.pact.provider.junit.target.TestTarget;
 import au.com.dius.pact.provider.spring.SpringRestPactRunner;
 import au.com.dius.pact.provider.spring.target.SpringBootHttpTarget;
 import uk.gov.companieshouse.extensions.api.groups.ContractProvider;
-import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestFullEntity;
-import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestsRepository;
-import uk.gov.companieshouse.extensions.api.requests.Status;
 
 @Category(ContractProvider.class)
 @RunWith(SpringRestPactRunner.class)
@@ -26,9 +22,6 @@ public class ContractProviderIntegrationTest {
 
     @TestTarget
     public final Target target = new SpringBootHttpTarget();
-
-    @Autowired
-    private ExtensionRequestsRepository repository;
 
     @State("I have a valid OPEN request for 00006400 with requestId aaaaaaaaaaaaaaaaaaaaaaa4")
     public void toPatchState() {}


### PR DESCRIPTION
it should not matter what the status of a request is. all thats being checked is that a patch request will return the correct data/response code/headers. Adding state assertions creates a brittle test in this case as the state of the request is irrelevant.