### PR TITLE
add reasonStatus to the dto

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonMapper.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonMapper.java
@@ -20,6 +20,7 @@ public class ExtensionReasonMapper {
         extensionReasonDTO.setReason(entity.getReason());
         extensionReasonDTO.setId(entity.getId());
         extensionReasonDTO.setLinks(entity.getLinks());
+        extensionReasonDTO.setReasonStatus(entity.getReasonStatus());
 
         Links attachments = new Links();
         Map<String, String> linksMap = new HashMap<>();

--- a/src/test/java/uk/gov/companieshouse/extensions/api/Utils/Utils.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/Utils/Utils.java
@@ -131,6 +131,7 @@ public class Utils {
         extensionReasonEntity.setStartOn(REASON_START_ON);
         extensionReasonEntity.setEndOn(REASON_END_ON);
         extensionReasonEntity.setReason(REASON);
+        extensionReasonEntity.setReasonStatus(ReasonStatus.DRAFT);
 
         return extensionReasonEntity;
     }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonMapperUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/reasons/ExtensionReasonMapperUnitTest.java
@@ -32,6 +32,7 @@ public class ExtensionReasonMapperUnitTest {
         assertEquals(extensionReasonEntity.getStartOn(), extensionReasonDTO.getStartOn());
         assertEquals(extensionReasonEntity.getEndOn(), extensionReasonDTO.getEndOn());
         assertEquals(extensionReasonEntity.getReason(), extensionReasonDTO.getReason());
+        assertEquals(extensionReasonEntity.getReasonStatus(), extensionReasonDTO.getReasonStatus());
 
         String attachmentName = attachment.getName();
         Map<String, String> dtoAttachmentLinks = extensionReasonDTO.getAttachments().getLinks();


### PR DESCRIPTION
Extensions web contract test is failing because it is expecting a reasonStatus to be returned in the Patch request as required in the spec.

Adding this to the mapper dto fixes the problem