### PR TITLE
sonar bug equals override needs hashCode method

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentDTO.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentDTO.java
@@ -85,4 +85,9 @@ public class AttachmentDTO extends ApiObjectImpl implements Serializable {
             Objects.equals(contentType, that.contentType) &&
             Objects.equals(id, that.id);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), size, name, contentType, id);
+    }
 }


### PR DESCRIPTION
Sonar bug highlighted equals implementation was not accompanied by a hashCode method.