### PR TITLE
FileTransferAPI integration test - Adding blank defaults for http_pro…

### DIFF
--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
@@ -59,10 +59,10 @@ public class FileTransferGatewayIntegrationTest {
     @Mock
     private HttpServletResponse mockHttpServletResponse;
 
-    @Value("${http_proxy}")
+    @Value("${http_proxy:}")
     private String envHttpProxy;
 
-    @Value("${https_proxy}")
+    @Value("${https_proxy:}")
     private String envHttpsProxy;
 
     @PostConstruct


### PR DESCRIPTION
…xy env vars

the http_proxy env vars are injected into the file transfer integration test if they are present. If they are not then this fix will default them to empty strings instead of the test failing because they are not present.