### PR TITLE
Renaming Concourse Integration targets to be CI Integration to avoid …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ test-unit: clean
 test-integration: clean
 	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.Integration"
 
-.PHONY: test-concourse-integration
-test-concourse-integration: clean
-	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.ConcourseIntegration"
+.PHONY: test-ci-integration
+test-ci-integration: clean
+	mvn verify -Dgroups="uk.gov.companieshouse.extensions.api.groups.CIIntegration"
 
 .PHONY: test-contract-consumer
 test-contract-consumer: clean

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.multipart.MultipartFile;
 
 import org.springframework.web.multipart.commons.CommonsMultipartFile;
-import uk.gov.companieshouse.extensions.api.groups.ConcourseIntegration;
+import uk.gov.companieshouse.extensions.api.groups.CIIntegration;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletOutputStream;
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 /**
  * FileTransferGatewayIntegrationTest
  */
-@Category(ConcourseIntegration.class)
+@Category(CIIntegration.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class FileTransferGatewayIntegrationTest {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/groups/CIIntegration.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/groups/CIIntegration.java
@@ -1,4 +1,4 @@
 package uk.gov.companieshouse.extensions.api.groups;
 
-public interface ConcourseIntegration {
+public interface CIIntegration {
 }


### PR DESCRIPTION
Renaming Concourse Integration targets to be CI Integration to avoid coupling
to a specific CI implementation (eg. concourse)