### PR TITLE
Some code smell fixes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.extensions.api.attachments.file;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -118,8 +119,9 @@ public class FileTransferApiClient {
      * @param clientHttpResponse the response back from the api we are calling - the file-transfer-api
      */
     private void setResponseHeaders(HttpServletResponse httpServletResponse, ClientHttpResponse clientHttpResponse) {
-        HttpHeaders incomingHeaders = clientHttpResponse.getHeaders();
-        if (incomingHeaders != null) {
+        Optional<HttpHeaders> incomingHeadersOpt = Optional.of(clientHttpResponse.getHeaders());
+        if (incomingHeadersOpt.isPresent()) {
+            HttpHeaders incomingHeaders = incomingHeadersOpt.get();
             MediaType contentType = incomingHeaders.getContentType();
             if (contentType != null) {
                 httpServletResponse.setHeader(CONTENT_TYPE, contentType.toString());

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
@@ -119,16 +119,13 @@ public class FileTransferApiClient {
      * @param clientHttpResponse the response back from the api we are calling - the file-transfer-api
      */
     private void setResponseHeaders(HttpServletResponse httpServletResponse, ClientHttpResponse clientHttpResponse) {
-        Optional<HttpHeaders> incomingHeadersOpt = Optional.of(clientHttpResponse.getHeaders());
-        if (incomingHeadersOpt.isPresent()) {
-            HttpHeaders incomingHeaders = incomingHeadersOpt.get();
-            MediaType contentType = incomingHeaders.getContentType();
-            if (contentType != null) {
-                httpServletResponse.setHeader(CONTENT_TYPE, contentType.toString());
-            }
-            httpServletResponse.setHeader(CONTENT_LENGTH, String.valueOf(incomingHeaders.getContentLength()));
-            httpServletResponse.setHeader(CONTENT_DISPOSITION, incomingHeaders.getContentDisposition().toString());
+        HttpHeaders incomingHeaders = clientHttpResponse.getHeaders();
+        MediaType contentType = incomingHeaders.getContentType();
+        if (contentType != null) {
+            httpServletResponse.setHeader(CONTENT_TYPE, contentType.toString());
         }
+        httpServletResponse.setHeader(CONTENT_LENGTH, String.valueOf(incomingHeaders.getContentLength()));
+        httpServletResponse.setHeader(CONTENT_DISPOSITION, incomingHeaders.getContentDisposition().toString());
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferApiClient.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.extensions.api.attachments.file;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/MongoDBTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/MongoDBTest.java
@@ -77,7 +77,7 @@ public class MongoDBTest {
         requestsRepository.deleteById(SUMMER_TEST_DOCUMENT);
     }
 
-    @Ignore
+    @Ignore("This requires an in-memory db similar to Derby but for Mongo")
     @Test
     public void testReasonDatesAreMidnightOnDateSpecifiedInMongoDB_InWinter()  throws JSONException {
         String documentId = WINTER_TEST_DOCUMENT;
@@ -88,7 +88,7 @@ public class MongoDBTest {
          assess(documentId);
     }
 
-    @Ignore
+    @Ignore("This requires an in-memory db similar to Derby but for Mongo")
     @Test
     public void testReasonDatesAreMidnightOnDateSpecifiedInMongoDB_InSummer()  throws JSONException {
         String documentId = SUMMER_TEST_DOCUMENT;


### PR DESCRIPTION
Addressed 3/8 code smells. Apparently adding comments to @Ignore should stop Sonar complaining about these.


The other 5 I'm not sure about they may break the code as Sonar itself is not taking into account what the code is being used in conjunction with; they can be seen here:


http://code-analysis.platform.aws.chdev.org:9000/project/issues?id=uk.gov.companieshouse%3Aextensions-api&resolved=false&types=CODE_SMELL