### PR TITLE
removed args from spring startup

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/Application.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/Application.java
@@ -14,7 +14,7 @@ public class Application {
   public static final String APP_NAMESPACE = "extensions-api";
 
   public static void main(String[] args) {
-    SpringApplication.run(Application.class, args);
+    SpringApplication.run(Application.class);
   }
 
     @Autowired


### PR DESCRIPTION
Sonar has cited the use of args in the spring application run method a a security vulnerability. They were added as part of the initial commit when extension api was started at the beginning of last year.

The args are not used in the promise to file api. Have checked the start sh for both applications and the main difference is that extensions uses proxy args.

Have rebuilt and run this along with running the unit tests - no problems found locally.