### PR TITLE
replace hardcoded spring data uri

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=4056
 api.endpoint.extensions=/company/{companyNumber}/extensions/requests
-spring.data.mongodb.uri=mongodb://mongo-db1-statler.dev.aws.internal:27017/extension_requests
+spring.data.mongodb.uri=${EXTENSIONS_API_MONGODB_URL}
 
 spring.servlet.multipart.max-file-size=${UPLOAD_MAX_FILE_SIZE}
 spring.servlet.multipart.max-request-size=${UPLOAD_MAX_REQUEST_SIZE}


### PR DESCRIPTION
In aws envt, this value is overridden in the start script.
Docker doesnt run this script so the hardcoded value remains.
https://github.com/companieshouse/extensions-api/blob/master/start.sh#L36