### PR TITLE
Remove extra lb for private route

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -42,15 +42,6 @@ data "aws_lb_listener" "service_lb_listener" {
   port = 443
 }
 
-data "aws_lb" "secondary_lb" {
-  name = "${var.environment}-chs-apichgovuk-private"
-}
-
-data "aws_lb_listener" "secondary_lb_listener" {
-  load_balancer_arn = data.aws_lb.secondary_lb.arn
-  port = 443
-}
-
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {
   path = "/${local.name_prefix}"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -33,12 +33,6 @@ module "ecs-service" {
   lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
   lb_listener_rule_priority       = local.lb_listener_rule_priority
   lb_listener_paths               = local.lb_listener_paths
-  multilb_listeners               = {
-      "priv-api-lb": {
-          listener_arn           = data.aws_lb_listener.secondary_lb_listener.arn,
-          load_balancer_arn      = data.aws_lb.secondary_lb.arn
-      }
-  }
 
   # ECS Task container health check
   use_task_container_healthcheck = true


### PR DESCRIPTION
Remove multi lb for private route, failing healthcheck and not needed. Extensions is an internal app.