### PR TITLE
[JU-1277] feat: simplify download endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,7 +13,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.multipart.MultipartFile;
 
-import uk.gov.companieshouse.extensions.api.attachments.file.FileTransferApiClientResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.extensions.api.logger.LogMethodCall;
 import uk.gov.companieshouse.service.ServiceException;

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsController.java
@@ -53,7 +53,7 @@ public class AttachmentsController {
             logger.error(e);
             return responseEntityFactory.createResponse(ServiceResult.notFound());
         } catch(HttpClientErrorException | HttpServerErrorException e) {
-            logger.error(String.format("The file-transfer-api has returned an error for file: %s", 
+            logger.error(String.format("The file-transfer-api has returned an error for file: %s",
                 file.getOriginalFilename()), e);
             return ResponseEntity.status(e.getStatusCode()).build();
         }
@@ -75,14 +75,7 @@ public class AttachmentsController {
 
     @LogMethodCall
     @GetMapping("/{requestId}/reasons/{reasonId}/attachments/{attachmentId}/download")
-    public ResponseEntity<Void> downloadAttachmentFromRequest(@PathVariable String attachmentId, HttpServletResponse response) {
-        try {
-            FileTransferApiClientResponse downloadServiceResult = attachmentsService.downloadAttachment(attachmentId, response);
-            return ResponseEntity.status(downloadServiceResult.getHttpStatus()).build();
-        } catch(HttpClientErrorException | HttpServerErrorException e) {
-            logger.error(String.format("The file-transfer-api has returned an error: %s for attachmentId %s",
-                e.getMessage(), attachmentId));
-            return ResponseEntity.status(e.getStatusCode()).build();
-        }
-    }	
+    public void downloadAttachmentFromRequest(@PathVariable String attachmentId, HttpServletResponse response) {
+        attachmentsService.downloadAttachment(attachmentId, response);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsService.java
@@ -167,7 +167,7 @@ public class AttachmentsService {
             "Request %s", reasonId, requestId));
     }
 
-    public FileTransferApiClientResponse downloadAttachment(String attachmentId, HttpServletResponse httpServletResponse) {
-        return fileTransferServiceClient.download(attachmentId, httpServletResponse);
+    public void downloadAttachment(String attachmentId, HttpServletResponse httpServletResponse) {
+        fileTransferServiceClient.download(attachmentId, httpServletResponse);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferServiceClient.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferServiceClient.java
@@ -1,6 +1,10 @@
 package uk.gov.companieshouse.extensions.api.attachments.file;
 
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -9,6 +13,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.servlet.http.HttpServletResponse;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
@@ -17,11 +23,6 @@ import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.IdApi;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.extensions.api.logger.LogMethodCall;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Client for using the file-transfer-service for upload / download / delete of files
@@ -76,9 +77,8 @@ public class FileTransferServiceClient {
 
         if (downloadResponse != null) {
             setResponseHeaders(httpServletResponse, downloadResponse);
-            OutputStream os;
-            try {
-                os = httpServletResponse.getOutputStream();
+
+            try (OutputStream os = httpServletResponse.getOutputStream()) {
                 os.write(downloadResponse.getData(), 0, downloadResponse.getData().length);
                 os.flush();
                 logger.debug("fileId " + fileId + " downloaded successfully");

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
@@ -1,6 +1,13 @@
 package uk.gov.companieshouse.extensions.api.attachments;
 
-import jakarta.servlet.http.HttpServletResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -18,20 +25,12 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.multipart.MultipartFile;
-import uk.gov.companieshouse.extensions.api.Utils.Utils;
+
 import uk.gov.companieshouse.extensions.api.attachments.file.FileTransferApiClientResponse;
 import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.HashMap;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 @Tag("IntegrationTest")
 @ExtendWith(SpringExtension.class)
@@ -108,10 +107,6 @@ public class AttachmentsControllerIntegrationTest {
 
     @Test
     public void testDownloadAttachmentFromRequest() throws Exception {
-        FileTransferApiClientResponse dummyDownloadResponse = Utils.dummyDownloadResponse();
-
-        when(attachmentsService.downloadAttachment(anyString(), any(HttpServletResponse.class)))
-            .thenReturn(dummyDownloadResponse);
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.get(DOWNLOAD_URL);
 
@@ -121,11 +116,6 @@ public class AttachmentsControllerIntegrationTest {
 
     @Test
     public void testDownloadAttachmentFromRequest_error() throws Exception {
-        FileTransferApiClientResponse dummyDownloadResponse = new FileTransferApiClientResponse();
-        dummyDownloadResponse.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
-
-        when(attachmentsService.downloadAttachment(anyString(), any(HttpServletResponse.class)))
-            .thenReturn(dummyDownloadResponse);
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders.get(DOWNLOAD_URL);
 

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsServiceUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsServiceUnitTest.java
@@ -438,16 +438,13 @@ public class AttachmentsServiceUnitTest {
     public void willCallFileTransferGatewayForDownload() {
         String attachmentId = "1234";
         HttpServletResponse httpServletResponse = new MockHttpServletResponse();
-        FileTransferApiClientResponse dummyDownloadResponse = Utils.dummyDownloadResponse();
 
-        when(fileTransferServiceClient.download(attachmentId, httpServletResponse)).thenReturn(dummyDownloadResponse);
-
-        FileTransferApiClientResponse downloadServiceResult = service.downloadAttachment(attachmentId, httpServletResponse);
+        service.downloadAttachment(attachmentId, httpServletResponse);
 
         verify(fileTransferServiceClient, only()).download(attachmentId, httpServletResponse);
         verify(fileTransferServiceClient, times(1)).download(attachmentId, httpServletResponse);
 
-        assertNotNull(downloadServiceResult);
+        assertEquals(200, httpServletResponse.getStatus());
     }
 
     private void addAttachmentToReason(ExtensionReasonEntity reason, String attachmentId) {

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/file/FileTransferGatewayIntegrationTest.java
@@ -142,12 +142,12 @@ public class FileTransferGatewayIntegrationTest {
         // Try to download after delete - should get 404
         try {
             System.out.println("Calling download...");
-            HttpStatus downloadStatus = await().atMost(Durations.ONE_MINUTE)
+            Integer downloadStatus = await().atMost(Durations.ONE_MINUTE)
                 .with()
                 .pollInterval(Durations.FIVE_SECONDS)
                 .until(downloadFile(fileID, mockHttpServletResponse), Objects::nonNull);
 
-            assertEquals(HttpStatus.NOT_FOUND, downloadStatus);
+            assertEquals(HttpStatus.NOT_FOUND.value(), downloadStatus);
         } catch (Exception e) {
             fail(e.getMessage());
         } finally {
@@ -188,15 +188,15 @@ public class FileTransferGatewayIntegrationTest {
         return gateway.upload(multipartFile);
     }
 
-    private Callable<HttpStatus> downloadFile(String fileID, HttpServletResponse httpServletResponse) {
+    private Callable<Integer> downloadFile(String fileID, HttpServletResponse httpServletResponse) {
         return () -> {
-            HttpStatus downloadStatus;
+            int downloadStatus;
             try {
                 System.out.print(".");
-                FileTransferApiClientResponse downloadResponse = gateway.download(fileID, httpServletResponse);
-                downloadStatus = downloadResponse.getHttpStatus();
+                gateway.download(fileID, httpServletResponse);
+                downloadStatus = httpServletResponse.getStatus();
             } catch (HttpClientErrorException | HttpServerErrorException e) {
-                downloadStatus = HttpStatus.valueOf(e.getStatusCode().value());
+                downloadStatus = e.getStatusCode().value();
             }
             return downloadStatus;
         };

--- a/src/test/java/uk/gov/companieshouse/extensions/api/authorization/AuthorizationIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/authorization/AuthorizationIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.extensions.api.authorization;
 
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -11,10 +10,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
 import uk.gov.companieshouse.extensions.api.attachments.AttachmentsController;
 import uk.gov.companieshouse.extensions.api.attachments.AttachmentsService;
 import uk.gov.companieshouse.extensions.api.attachments.file.FileTransferApiClientResponse;
@@ -22,10 +23,6 @@ import uk.gov.companieshouse.extensions.api.logger.ApiLogger;
 import uk.gov.companieshouse.extensions.api.requests.ERICHeaderParser;
 import uk.gov.companieshouse.extensions.api.requests.ExtensionRequestMapper;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 @Tag("IntegrationTest")
 @WebMvcTest(value = {AttachmentsController.class})
@@ -35,19 +32,19 @@ public class AuthorizationIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private AttachmentsService attachmentsService;
 
-    @MockBean
+    @MockitoBean
     private ERICHeaderParser headerParser;
 
-    @MockBean
+    @MockitoBean
     private ExtensionRequestMapper mapper;
 
-    @MockBean
+    @MockitoBean
     private ApiLogger logger;
 
-    @MockBean
+    @MockitoBean
     private PluggableResponseEntityFactory responseEntityFactory;
 
     @BeforeEach
@@ -55,8 +52,6 @@ public class AuthorizationIntegrationTest {
         FileTransferApiClientResponse transferResponse = new FileTransferApiClientResponse();
         transferResponse.setFileId("123");
         transferResponse.setHttpStatus(HttpStatus.OK);
-        when(attachmentsService.downloadAttachment(anyString(), any(HttpServletResponse.class)))
-            .thenReturn(transferResponse);
     }
 
     @Test


### PR DESCRIPTION
  The download endpoint could return a HTTP Response 2 way:
    * the response passed into the method if a file is sucessfully obtained from the `file-transfer-service`
    * an instance of the FileTransferApiClientResponse This can cause confusion and should be simplified