### PR TITLE
ASM-2180 Spring 4 upgrade and fix security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,11 @@
         <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
 
-        <structured-logging.version>3.0.48</structured-logging.version>
-        <rest-service-common-library.version>2.0.9</rest-service-common-library.version>
-        <private-api-sdk-java.version>4.0.447</private-api-sdk-java.version>
-        <api-sdk-java.version>6.6.3</api-sdk-java.version>
+        <!-- CH dependencies -->
+        <structured-logging.version>3.0.55</structured-logging.version>
+        <rest-service-common-library.version>2.0.11</rest-service-common-library.version>
+        <private-api-sdk-java.version>6.0.1</private-api-sdk-java.version>
+        <api-sdk-java.version>6.6.16</api-sdk-java.version>
 
         <tika-core.version>3.2.2</tika-core.version>
         <commons-io.version>2.20.0</commons-io.version>
@@ -82,13 +83,13 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- override assertj-core to fix CVE-2026-24400 - transitive dependency from spring-boot-starter-test which depends on spring-boot-dependencies -->
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>3.27.7</version>
-                <scope>test</scope>
-            </dependency>
+<!--            &lt;!&ndash; override assertj-core to fix CVE-2026-24400 - transitive dependency from spring-boot-starter-test which depends on spring-boot-dependencies &ndash;&gt;-->
+<!--            <dependency>-->
+<!--                <groupId>org.assertj</groupId>-->
+<!--                <artifactId>assertj-core</artifactId>-->
+<!--                <version>3.27.7</version>-->
+<!--                <scope>test</scope>-->
+<!--            </dependency>-->
         </dependencies>
     </dependencyManagement>
 
@@ -284,4 +285,10 @@
             </plugin>
         </plugins>
     </build>
+
+    <!--
+        CVE-2025-41249 (HIGH, spring-core): No fixed version available as of 2026-04-29.
+        See: https://github.com/advisories/GHSA-jmp9-x22r-554x
+        If you use @EnableMethodSecurity or security annotations on methods in generic superclasses/interfaces, review your code and apply runtime mitigations as recommended by Spring.
+    -->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <version>${mongodb.version}</version>
@@ -225,11 +229,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjweaver</artifactId>
-            <version>1.9.22</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
         <log4j2.version>2.25.4</log4j2.version>
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
         <mapstruct.version>1.6.3</mapstruct.version>
-        <surefire-plugin.version>3.5.4</surefire-plugin.version>
-        <junit.jupiter.version>5.13.4</junit.jupiter.version>
-        <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
-        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <surefire-plugin.version>3.5.5</surefire-plugin.version>
+        <junit.jupiter.version>5.14.4</junit.jupiter.version>
+        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 
         <!-- CH dependencies -->
         <structured-logging.version>3.0.55</structured-logging.version>
@@ -30,13 +30,13 @@
         <private-api-sdk-java.version>6.0.1</private-api-sdk-java.version>
         <api-sdk-java.version>6.6.16</api-sdk-java.version>
 
-        <tika-core.version>3.2.2</tika-core.version>
-        <commons-io.version>2.20.0</commons-io.version>
+        <tika-core.version>3.3.0</tika-core.version>
+        <commons-io.version>2.22.0</commons-io.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <mongodb.version>5.3.1</mongodb.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
 
         <!--  Sonar -->
         <sonar.projectName>extensions-api</sonar.projectName>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
 
-        <log4j2.version>2.25.4</log4j2.version>
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
@@ -77,13 +76,6 @@
                 <version>${opentelemetry-semconv.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j2.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
 
         <log4j2.version>2.25.4</log4j2.version>
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
@@ -23,12 +23,13 @@
         <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <opentelemetry-semconv.version>1.42.0</opentelemetry-semconv.version>
 
         <!-- CH dependencies -->
-        <structured-logging.version>3.0.55</structured-logging.version>
-        <rest-service-common-library.version>2.0.11</rest-service-common-library.version>
-        <private-api-sdk-java.version>6.0.1</private-api-sdk-java.version>
-        <api-sdk-java.version>6.6.16</api-sdk-java.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
+        <rest-service-common-library.version>2.0.14</rest-service-common-library.version>
+        <private-api-sdk-java.version>6.0.33</private-api-sdk-java.version>
+        <api-sdk-java.version>7.0.3</api-sdk-java.version>
 
         <tika-core.version>3.3.0</tika-core.version>
         <commons-io.version>2.22.0</commons-io.version>
@@ -68,6 +69,14 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <!--      fixes CVE-2026-41178(5.3)-->
+            <dependency>
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>${opentelemetry-semconv.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot-dependencies.version>3.5.10</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.10</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>4.0.6</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>4.0.6</spring-boot-maven-plugin.version>
 
-        <log4j2.version>2.25.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <environment-reader-library.version>3.0.3</environment-reader-library.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
@@ -82,14 +82,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-<!--            &lt;!&ndash; override assertj-core to fix CVE-2026-24400 - transitive dependency from spring-boot-starter-test which depends on spring-boot-dependencies &ndash;&gt;-->
-<!--            <dependency>-->
-<!--                <groupId>org.assertj</groupId>-->
-<!--                <artifactId>assertj-core</artifactId>-->
-<!--                <version>3.27.7</version>-->
-<!--                <scope>test</scope>-->
-<!--            </dependency>-->
         </dependencies>
     </dependencyManagement>
 
@@ -141,7 +133,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.vintage</groupId>
@@ -152,11 +144,13 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <version>${spring-boot-dependencies.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -232,7 +226,11 @@
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>1.9.22</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -285,10 +283,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <!--
-        CVE-2025-41249 (HIGH, spring-core): No fixed version available as of 2026-04-29.
-        See: https://github.com/advisories/GHSA-jmp9-x22r-554x
-        If you use @EnableMethodSecurity or security annotations on methods in generic superclasses/interfaces, review your code and apply runtime mitigations as recommended by Spring.
-    -->
 </project>

--- a/src/main/java/uk/gov/companieshouse/extensions/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/config/InterceptorConfig.java
@@ -4,13 +4,12 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
-import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.DefaultErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import uk.gov.companieshouse.extensions.api.authorization.CompanyAuthorizationInterceptor;
@@ -50,10 +49,5 @@ public class InterceptorConfig implements WebMvcConfigurer {
                 return null;
             }
         };
-    }
-
-    @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
-        configurer.setUseTrailingSlashMatch(true);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/reasons/ReasonsController.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.service.ServiceResult;
 import java.net.URI;
 
 @RestController
-@RequestMapping("${api.endpoint.extensions}")
+@RequestMapping("/company/{companyNumber}/extensions/requests")
 public class ReasonsController {
 
     private final ReasonsService reasonsService;

--- a/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
+++ b/src/main/java/uk/gov/companieshouse/extensions/api/requests/RequestsController.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/")
+@RequestMapping("/company/{companyNumber}/extensions/requests")
 public class RequestsController {
 
     @Autowired
@@ -40,7 +40,7 @@ public class RequestsController {
     private ApiLogger logger;
 
     @LogMethodCall
-    @PostMapping("${api.endpoint.extensions}")
+    @PostMapping(path = {"", "/"})
     public ResponseEntity<ExtensionRequestFullDTO> createExtensionRequestResource(
         @RequestBody ExtensionCreateRequest extensionCreateRequest, HttpServletRequest request,
         @PathVariable String companyNumber) {
@@ -71,7 +71,7 @@ public class RequestsController {
     }
 
     @LogMethodCall
-    @GetMapping("${api.endpoint.extensions}")
+    @GetMapping(path = {"", "/"})
     public ResponseEntity<ListResponse<ExtensionRequestFullDTO>> getExtensionRequestsListByCompanyNumber(
         @PathVariable String companyNumber) {
 
@@ -85,14 +85,14 @@ public class RequestsController {
     }
 
     @LogMethodCall
-    @GetMapping("${api.endpoint.extensions}/{requestId}")
+    @GetMapping("/{requestId}")
     public ResponseEntity<ExtensionRequestFullEntity> getSingleExtensionRequestById(@PathVariable String requestId) {
         return requestsService.getExtensionsRequestById(requestId).map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }
 
     @LogMethodCall
-    @PatchMapping("${api.endpoint.extensions}/{requestId}")
+    @PatchMapping("/{requestId}")
     public ResponseEntity<ExtensionRequestFullEntity> patchRequest(@PathVariable String requestId,
                                                                    @RequestBody RequestStatus requestStatus) {
         try {
@@ -104,7 +104,7 @@ public class RequestsController {
     }
 
     @LogMethodCall
-    @DeleteMapping("${api.endpoint.extensions}/{requestId}")
+    @DeleteMapping("/{requestId}")
     public boolean deleteExtensionRequestById(@PathVariable String requestId) {
         return false;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.port=${EXTENSIONS_API_PORT:4056}
-api.endpoint.extensions=/company/{companyNumber}/extensions/requests
-spring.data.mongodb.uri=${EXTENSIONS_API_MONGODB_URL}
+spring.mongodb.uri=${EXTENSIONS_API_MONGODB_URL}
 
 spring.servlet.multipart.max-file-size=${UPLOAD_MAX_FILE_SIZE}
 spring.servlet.multipart.max-request-size=${UPLOAD_MAX_REQUEST_SIZE}

--- a/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/attachments/AttachmentsControllerIntegrationTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
@@ -29,8 +29,8 @@ import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactory;
 
+@ExtendWith(MockitoExtension.class)
 @Tag("IntegrationTest")
-@ExtendWith(SpringExtension.class)
 class AttachmentsControllerIntegrationTest {
 
     private static final String ROOT_URL = "/company/00006400/extensions/requests/a1" +

--- a/src/test/java/uk/gov/companieshouse/extensions/api/authorization/AuthorizationIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/authorization/AuthorizationIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactor
 @Tag("IntegrationTest")
 @WebMvcTest(value = {AttachmentsController.class})
 @TestPropertySource({"classpath:test.properties"})
-public class AuthorizationIntegrationTest {
+class AuthorizationIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -54,7 +54,7 @@ public class AuthorizationIntegrationTest {
     }
 
     @Test
-    public void willNotAllowUserToDownload() throws Exception {
+    void willNotAllowUserToDownload() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get("/company/00006400/extensions/requests/1/reasons/2/attachments/3/download")
             .accept(MediaType.APPLICATION_JSON);
@@ -64,7 +64,7 @@ public class AuthorizationIntegrationTest {
     }
 
     @Test
-    public void willAllowAdminToDownloadWithCorrectPermissions() throws Exception {
+    void willAllowAdminToDownloadWithCorrectPermissions() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get("/company/00006400/extensions/requests/1/reasons/2/attachments/3/download")
             .accept(MediaType.APPLICATION_JSON)
@@ -76,7 +76,7 @@ public class AuthorizationIntegrationTest {
     }
 
     @Test
-    public void willRejectAdminDownloadIfNoDownloadPermission() throws Exception {
+    void willRejectAdminDownloadIfNoDownloadPermission() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get("/company/00006400/extensions/requests/1/reasons/2/attachments/3/download")
             .accept(MediaType.APPLICATION_JSON)
@@ -88,7 +88,7 @@ public class AuthorizationIntegrationTest {
     }
 
     @Test
-    public void willRejectAdminToDelete() throws Exception {
+    void willRejectAdminToDelete() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .delete("/company/00006400/extensions/requests/1/reasons/2/attachments/3")
             .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/ErrorAttributesIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/ErrorAttributesIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerIntegrationTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
@@ -37,10 +37,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.COMPANY_NUMBER;
 
 @Tag("IntegrationTest")
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {"EXTENSIONS_API_MONGODB_URL=mongodb://mongo-db1-toro1.development.aws.internal:27017", "server.port=8093",
     "api.endpoint.extensions=/company/{companyNumber}/extensions/requests",
-    "spring.data.mongodb.uri=mongodb://mongo-db1-toro1.development.aws.internal:27017/extension_requests",
+    "spring.mongodb.uri=mongodb://mongo-db1-toro1.development.aws.internal:27017/extension_requests",
     "FILE_TRANSFER_API_URL=http://localhost:8081/",
     "FILE_TRANSFER_API_KEY=12345",
     "MONGO_CONNECTION_POOL_MIN_SIZE=0",
@@ -49,7 +49,7 @@ import static uk.gov.companieshouse.extensions.api.Utils.Utils.COMPANY_NUMBER;
     "spring.servlet.multipart.max-file-size=100",
     "spring.servlet.multipart.max-request-size=200"})
 @SpringBootTest(classes = RequestsController.class)
-public class RequestControllerIntegrationTest {
+class RequestControllerIntegrationTest {
 
     private static final String ROOT_URL = "/company/00006400/extensions/requests";
     private static final String REQUEST_BY_ID_URL = "/company/00006400/extensions/requests/a1";
@@ -110,7 +110,7 @@ public class RequestControllerIntegrationTest {
     }
 
     @Test
-    public void testCreateExtensionRequestResource() throws Exception {
+    void testCreateExtensionRequestResource() throws Exception {
         String request = buildMockRequest();
 
         when(extensionRequestMapper.entityToDTO(
@@ -134,7 +134,7 @@ public class RequestControllerIntegrationTest {
     }
 
     @Test
-    public void testGetExtensionRequestsList() throws Exception {
+    void testGetExtensionRequestsList() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get(ROOT_URL)
             .accept(MediaType.APPLICATION_JSON);
@@ -154,7 +154,7 @@ public class RequestControllerIntegrationTest {
     }
 
     @Test
-    public void testGetSingleExtensionRequest() throws Exception {
+    void testGetSingleExtensionRequest() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get(REQUEST_BY_ID_URL)
             .accept(MediaType.APPLICATION_JSON);
@@ -170,7 +170,7 @@ public class RequestControllerIntegrationTest {
     }
 
     @Test
-    public void testDeleteExtensionRequest() throws Exception {
+    void testDeleteExtensionRequest() throws Exception {
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .delete(REQUEST_BY_ID_URL)
             .accept(MediaType.APPLICATION_JSON);

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestControllerUnitTest.java
@@ -41,11 +41,10 @@ import static uk.gov.companieshouse.extensions.api.Utils.Utils.USER_ID;
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestDTO;
 import static uk.gov.companieshouse.extensions.api.Utils.Utils.dummyRequestEntity;
 
-;
 
 @Tag("UnitTest")
 @ExtendWith(MockitoExtension.class)
-public class RequestControllerUnitTest {
+class RequestControllerUnitTest {
 
     @InjectMocks
     private RequestsController controller;
@@ -69,9 +68,8 @@ public class RequestControllerUnitTest {
     private ApiLogger logger;
 
     @Test
-    public void createsExtensionRequestResource() throws UnsupportedEncodingException {
+    void createsExtensionRequestResource() throws UnsupportedEncodingException {
         ExtensionCreateRequest createRequest = dummyRequest();
-        String requestUri = mockHttpServletRequest.getRequestURI();
         ExtensionRequestFullEntity entity = dummyRequestEntity();
         ExtensionRequestFullDTO entityRequestDTO = dummyRequestDTO();
 
@@ -94,7 +92,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void willGive500IfUnsupportedEncodingException() throws UnsupportedEncodingException {
+    void willGive500IfUnsupportedEncodingException() throws UnsupportedEncodingException {
         ExtensionCreateRequest createRequest = dummyRequest();
 
         when(mockEricHeaderParser.getForename(eq(mockHttpServletRequest)))
@@ -108,7 +106,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void canGetExtensionRequestList() {
+    void canGetExtensionRequestList() {
         ExtensionRequestFullEntity extensionRequestFullEntity = dummyRequestEntity();
         ExtensionRequestFullDTO extensionRequestFullDTO = dummyRequestDTO();
         List<ExtensionRequestFullEntity> extensionRequestFullEntityList = new ArrayList<>();
@@ -127,7 +125,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void canGetSingleExtensionRequest() {
+    void canGetSingleExtensionRequest() {
         ExtensionRequestFullEntity extensionRequestFullEntity = new ExtensionRequestFullEntity();
         extensionRequestFullEntity.setId("1234");
         ExtensionReasonEntity reasonEntity = new ExtensionReasonEntity();
@@ -145,7 +143,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void canGetSingleExtensionRequest_NotFound() {
+    void canGetSingleExtensionRequest_NotFound() {
         when(requestsService.getExtensionsRequestById("1234")).thenReturn(Optional.ofNullable(null));
         ResponseEntity<ExtensionRequestFullEntity> response = controller.getSingleExtensionRequestById("1234");
         Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -153,7 +151,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void willReturn204WhenAPatchRequestIsSubmitted() throws ServiceException {
+    void willReturn204WhenAPatchRequestIsSubmitted() throws ServiceException {
         when(requestsService.patchRequest(anyString(), any(RequestStatus.class)))
             .thenReturn(new ExtensionRequestFullEntity());
 
@@ -164,7 +162,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void willReturn404WhenRequestNotFound() throws ServiceException {
+    void willReturn404WhenRequestNotFound() throws ServiceException {
         when(requestsService.patchRequest(anyString(), any(RequestStatus.class)))
             .thenThrow(new ServiceException("not found"));
 
@@ -175,7 +173,7 @@ public class RequestControllerUnitTest {
     }
 
     @Test
-    public void canDeleteExtensionRequest() {
+    void canDeleteExtensionRequest() {
         boolean response = controller.deleteExtensionRequestById("123");
         assertFalse(response);
     }

--- a/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/extensions/api/requests/RequestRepositoryIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(properties = {"EXTENSIONS_API_MONGODB_URL=mongodb://mongo-db1-toro1.development.aws.internal:27017", "server.port=8093",
     "api.endpoint.extensions=/company/{companyNumber}/extensions/requests",
-    "spring.data.mongodb.uri=mongodb://mongo-db1-toro1.development.aws.internal:27017/extension_requests",
+    "spring.mongodb.uri=mongodb://mongo-db1-toro1.development.aws.internal:27017/extension_requests",
     "file.transfer.api.url=http://localhost:8081/",
     "internal.api.key=12345",
     "MONGO_CONNECTION_POOL_MIN_SIZE=0",
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
     "spring.servlet.multipart.max-file-size=100",
     "spring.servlet.multipart.max-request-size=200"})
 @SpringBootTest
-public class RequestRepositoryIntegrationTest {
+class RequestRepositoryIntegrationTest {
 
     private static final String REQUEST_1 = "aaaaaaaaaaaaaaaaaaaaaaa1";
     private static final String REQUEST_2 = "aaaaaaaaaaaaaaaaaaaaaaa2";
@@ -51,7 +51,7 @@ public class RequestRepositoryIntegrationTest {
     private ExtensionRequestsRepository requestsRepository;
 
     @Test
-    public void canGetRequestFromDB() {
+    void canGetRequestFromDB() {
         Optional<ExtensionRequestFullEntity> dummyData = requestsRepository.findById(REQUEST_1);
 
         Assertions.assertTrue(dummyData.isPresent());
@@ -69,7 +69,7 @@ public class RequestRepositoryIntegrationTest {
     }
 
     @Test
-    public void canSaveRequestToDB() {
+    void canSaveRequestToDB() {
         ExtensionRequestFullEntity expectedEntity = Utils.dummyRequestEntity();
         expectedEntity.setId(UUID.randomUUID().toString());
 
@@ -85,7 +85,7 @@ public class RequestRepositoryIntegrationTest {
     }
 
     @Test
-    public void canUpdateRequestToSaveReason() throws Exception {
+    void canUpdateRequestToSaveReason() throws Exception {
         ExtensionRequestFullEntity expectedEntity =
             requestsRepository.findById(REQUEST_2)
                 .orElseThrow(() -> new Exception("Request not found in DB"));
@@ -107,7 +107,7 @@ public class RequestRepositoryIntegrationTest {
     }
 
     @Test
-    public void canSaveAttachmentToReason() throws Exception {
+    void canSaveAttachmentToReason() throws Exception {
         ExtensionRequestFullEntity entity =
             requestsRepository.findById(REQUEST_3)
                 .orElseThrow(() -> new Exception("Request not found in DB"));
@@ -141,7 +141,7 @@ public class RequestRepositoryIntegrationTest {
     }
 
     @Test
-    public void canGetMultipleRequestsFromDB() throws Exception {
+    void canGetMultipleRequestsFromDB() throws Exception {
         ExtensionRequestFullEntity dummyEntity = requestsRepository.findById(REQUEST_1)
             .orElseThrow(() -> new Exception("Request not found in DB"));
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ASM-2180


This pull request contains several significant updates to dependencies, configuration, and controller endpoints to modernize the codebase, address security vulnerabilities, and align with updated Spring Boot conventions. The most notable changes include upgrading Spring Boot and related dependencies, refactoring controller request mappings to use hardcoded paths, and updating test and configuration files to match the new conventions.

**Dependency and configuration updates:**

* Upgraded Spring Boot to version `4.1.0` and updated related dependencies (such as `log4j2`, `junit.jupiter`, `surefire-plugin`, etc.), including security-related updates and the addition of `opentelemetry-semconv` to address CVE-2026-41178. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L16-R40) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R72-R79)
* Updated dependency versions for several internal and third-party libraries (e.g., `structured-logging`, `rest-service-common-library`, `private-api-sdk-java`, `api-sdk-java`, `tika-core`, `commons-io`, `commons-lang3`).
* Added `spring-boot-starter-aspectj` as a dependency and adjusted test dependencies to use `spring-boot-starter-webmvc-test` and `spring-boot-test-autoconfigure` instead of previous test starters. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R111-R114) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L143-R149) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L154-R166)
* Removed the explicit override for `assertj-core` as it is no longer needed due to the Spring Boot upgrade.

**Controller and endpoint changes:**

* Refactored the `ReasonsController` and `RequestsController` to use hardcoded request mappings (`/company/{companyNumber}/extensions/requests`) instead of property-based mappings, and updated all related endpoint annotations for consistency. [[1]](diffhunk://#diff-d9b46aa24d0a30338cbee442cbfb010687e28e58e2ea3f3ee3cae38281c8297cL24-R24) [[2]](diffhunk://#diff-f9529be4635ea061227c7641ec3876547f4b3a3d67de10cdfd107d811352d8d1L27-R27) [[3]](diffhunk://#diff-f9529be4635ea061227c7641ec3876547f4b3a3d67de10cdfd107d811352d8d1L43-R43) [[4]](diffhunk://#diff-f9529be4635ea061227c7641ec3876547f4b3a3d67de10cdfd107d811352d8d1L74-R74) [[5]](diffhunk://#diff-f9529be4635ea061227c7641ec3876547f4b3a3d67de10cdfd107d811352d8d1L88-R95) [[6]](diffhunk://#diff-f9529be4635ea061227c7641ec3876547f4b3a3d67de10cdfd107d811352d8d1L107-R107)
* Updated `application.properties` to remove the `api.endpoint.extensions` property and align MongoDB URI configuration with new conventions (`spring.mongodb.uri`).

**Spring Boot and test configuration:**

* Updated imports and usage of error attribute classes in `InterceptorConfig` to use new Spring Boot 4.x `webmvc` packages, and removed deprecated methods. [[1]](diffhunk://#diff-740245f19856850b0c2b7f6a92882f405d7e4dce855a01aa5141edee483b7176L7-L13) [[2]](diffhunk://#diff-740245f19856850b0c2b7f6a92882f405d7e4dce855a01aa5141edee483b7176L54-L58)
* Updated test classes to use new `webmvc.test.autoconfigure.WebMvcTest` and `MockitoExtension`, and modernized test method signatures (e.g., removing `public` and using package-private). [[1]](diffhunk://#diff-ac65ecd5eb61c782de46ef557aa2c0ab729054908691a912889a08b02d6e932aR16-L20) [[2]](diffhunk://#diff-ac65ecd5eb61c782de46ef557aa2c0ab729054908691a912889a08b02d6e932aR32-L33) [[3]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL8-R8) [[4]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL29-R29) [[5]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL57-R57) [[6]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL67-R67) [[7]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL79-R79) [[8]](diffhunk://#diff-ab8db29e761fe21487e99339d359d6befb936f9ec529222db22aabf2b6041eedL91-R91) [[9]](diffhunk://#diff-7395a5f4ae00d69758c69bd06a7422282ef6dd296cd48bc6cc1fde84e4af4ffbL8-R8) [[10]](diffhunk://#diff-6ff2d92fa0e29d892911d7bd9bf1c915597a282839694cfa4045b7aae5a57f0eR11-L15) [[11]](diffhunk://#diff-6ff2d92fa0e29d892911d7bd9bf1c915597a282839694cfa4045b7aae5a57f0eL40-R43)

These changes collectively bring the project up to date with the latest Spring Boot ecosystem, improve security posture, and standardize endpoint and configuration management.